### PR TITLE
Use build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.1.0
-        with:
-          python-version: 3.8
-
-      - id: install-dpf
+      - name: "Install DPF"
+        id: install-dpf
         uses: ./install-dpf-server
         with:
           dpf-standalone-TOKEN: ${{secrets.DPF_PIPELINE}}
@@ -62,6 +58,16 @@ jobs:
           cd ${{ steps.install-dpf.outputs.SERVER }}
           ls .
         shell: pwsh
+
+      - name: "Setup Python"
+        uses: actions/setup-python@v4.1.0
+        with:
+          python-version: 3.8
+
+      - name: "Install psutil"
+        shell: bash
+        run: |
+          pip install psutil
 
       - name: "Kill all servers"
         uses: ./kill-dpf-servers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup Python
+        uses: actions/setup-python@v4.1.0
+        with:
+          python-version: 3.8
+
       - id: install-dpf
         uses: ./install-dpf-server
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
           cd ${{ steps.install-dpf.outputs.SERVER }}
           ls .
 
+      - name: "Setup Python"
+        uses: actions/setup-python@v4.1.0
+        with:
+          python-version: 3.8
+
+      - name: "Install psutil"
+        shell: bash
+        run: |
+          pip install psutil
+
       - name: "Kill all servers"
         uses: ./kill-dpf-servers
 

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -87,7 +87,7 @@ runs:
       shell: bash
       run: |
         export SPHINX_APIDOC_OPTIONS=inherited-members
-        sphinx-apidoc -o docs/source/api ansys ${{inputs.build_extras}} -f --implicit-namespaces --separate --no-headings $DEBUG_SPHINX
+        sphinx-apidoc -o docs/source/api src/ansys ${{inputs.build_extras}} -f --implicit-namespaces --separate --no-headings $DEBUG_SPHINX
 
     - name: "Build HTML Documentation"
       shell: bash

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: "Debug mode"
       shell: bash
-      if: inputs.debug == 'true'
+      if: inputs.debug == 'false'
       run: |
         echo "DEBUG_SPHINX=&>log_sphinx.txt" >> $GITHUB_ENV
         echo "DEBUG_HTML=&>log_html.txt" >> $GITHUB_ENV

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -100,6 +100,7 @@ runs:
       with:
         name: doc-${{inputs.PACKAGE_NAME}}-log
         path: docs/*.txt
+      if: always()
 
     - name: "Zip Documentation"
       uses: vimtor/action-zip@v1

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -84,7 +84,7 @@ runs:
       run: |
         export TEMP=${{ runner.temp }}
         sudo apt update
-        sudo apt install texlive-latex-extra latexmk
+        sudo apt install pandoc texlive-latex-extra latexmk
         echo "Making pdf doc..."
         make pdf 
 

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Whether to generate the PDF doc"
     required: false
     default: "true"
+  debug:
+    description: "Output log directly"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -36,6 +40,14 @@ runs:
       uses: actions/setup-python@v2.1.4
       with:
         python-version: ${{ inputs.python-version }}
+
+    - name: "Debug mode"
+      shell: bash
+      if: inputs.debug == 'true'
+      run: |
+        echo "DEBUG_SPHINX=&>log_sphinx.txt" >> $GITHUB_ENV
+        echo "DEBUG_HTML=&>log_html.txt" >> $GITHUB_ENV
+        echo "DEBUG_PDF=&>log_pdf.txt" >> $GITHUB_ENV
 
     - name: "Install OS packages"
       shell: bash
@@ -75,7 +87,7 @@ runs:
       shell: bash
       run: |
         export SPHINX_APIDOC_OPTIONS=inherited-members
-        sphinx-apidoc -o docs/source/api ansys ${{inputs.build_extras}} -f --implicit-namespaces --separate --no-headings &>log_sphinx.txt
+        sphinx-apidoc -o docs/source/api ansys ${{inputs.build_extras}} -f --implicit-namespaces --separate --no-headings $DEBUG_SPHINX
 
     - name: "Build HTML Documentation"
       shell: bash
@@ -84,7 +96,7 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html
+        make html $DEBUG_HTML
 
     - name: "Build PDF Documentation"
       shell: bash
@@ -93,7 +105,7 @@ runs:
       run: |
         export TEMP=${{ runner.temp }}
         echo "Making pdf doc..."
-        make pdf &>log_pdf.txt
+        make pdf $DEBUG_PDF
 
     - name: "Upload Documentation Build log"
       uses: actions/upload-artifact@v3

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -84,7 +84,7 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html &>log_html.txt
+        make html
 
     - name: "Build PDF Documentation"
       shell: bash

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: "Zip HTML Documentation"
       uses: vimtor/action-zip@v1
       with:
-        files: ./docs/build/html/*
+        files: docs/build/html
         dest: HTML-doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Upload HTML Documentation"
@@ -117,7 +117,7 @@ runs:
     - name: "Zip PDF Documentation"
       uses: vimtor/action-zip@v1
       with:
-        files: ./docs/build/latex/*.pdf
+        files: "docs/build/latex/.*.pdf"
         dest: PDF-doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Upload PDF Documentation"

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -21,6 +21,9 @@ inputs:
   install_extras:
     description: "Extras to install for the local package"
     required: false
+  build_extras:
+    description: "Extra paths to build the doc for in the spinx-api command"
+    required: false
 
 runs:
   using: "composite"
@@ -62,7 +65,7 @@ runs:
       shell: bash
       run: |
         export SPHINX_APIDOC_OPTIONS=inherited-members
-        sphinx-apidoc -o docs/source/api ansys -f --implicit-namespaces --separate --no-headings &>log_sphinx.txt
+        sphinx-apidoc -o docs/source/api ansys ${{inputs.build_extras}} -f --implicit-namespaces --separate --no-headings &>log_sphinx.txt
 
     - name: "Build HTML Documentation"
       shell: bash

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -27,7 +27,7 @@ inputs:
   generate_pdf:
     description: "Whether to generate the PDF doc"
     required: false
-    default: "True"
+    default: "true"
 
 runs:
   using: "composite"
@@ -89,7 +89,7 @@ runs:
     - name: "Build PDF Documentation"
       shell: bash
       working-directory: docs
-      if: ${{ inputs.generate_pdf == 'True' }}
+      if: ${{ inputs.generate_pdf == 'true' }}
       run: |
         export TEMP=${{ runner.temp }}
         echo "Making pdf doc..."
@@ -114,15 +114,27 @@ runs:
         name: HTML-doc-${{inputs.PACKAGE_NAME}}
         path: HTML-doc-${{inputs.PACKAGE_NAME}}.zip
 
+    - name: "Find PDF Documentation"
+      shell: bash
+      if: ${{ inputs.generate_pdf == 'true' }}
+      id: pdf
+      working-directory: docs/build/latex
+      run: |
+        pattern="PyDPF-*.pdf"
+        files=( $pattern )
+        echo "::set-output name=PDF_file::${files[0]}"
+        echo "Found PDF doc: ${files[0]}"
+
     - name: "Zip PDF Documentation"
       uses: vimtor/action-zip@v1
+      if: ${{ inputs.generate_pdf == 'true' }}
       with:
-        files: "docs/build/latex/.*.pdf"
+        files: docs/build/latex/${{ steps.pdf.outputs.PDF_file }}
         dest: PDF-doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Upload PDF Documentation"
       uses: actions/upload-artifact@v3
-      if: ${{ inputs.generate_pdf == 'True' }}
+      if: ${{ inputs.generate_pdf == 'true' }}
       with:
         name: PDF-doc-${{inputs.PACKAGE_NAME}}
         path: PDF-doc-${{inputs.PACKAGE_NAME}}.zip

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -80,7 +80,7 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        xvfb-run make html 
+        make html 
 
 #        &>log_html.txt
 

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -80,7 +80,7 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html 
+        xvfb-run make html 
 
 #        &>log_html.txt
 

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -69,7 +69,7 @@ runs:
     - name: "Install documentation requirements"
       shell: bash
       run: |
-        pip install -r requirements_docs.txt
+        pip install -r requirements/requirements_docs.txt
 
     - name: "Build sphinx doc"
       shell: bash

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -84,7 +84,9 @@ runs:
         sudo apt update
         sudo apt install texlive-latex-extra latexmk
         echo "Making pdf doc..."
-        make pdf &>log_pdf.txt
+        make pdf 
+
+#        &>log_pdf.txt
 
     - name: "Upload Documentation Build log"
       uses: actions/upload-artifact@v2

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -33,6 +33,12 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    - name: "Install OS packages"
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install pandoc texlive-latex-extra latexmk
+
     - name: "Install DPF"
       uses: pyansys/pydpf-actions/install-dpf-server@v2.1
       with:
@@ -83,8 +89,6 @@ runs:
       working-directory: docs
       run: |
         export TEMP=${{ runner.temp }}
-        sudo apt update
-        sudo apt install pandoc texlive-latex-extra latexmk
         echo "Making pdf doc..."
         make pdf 
 
@@ -97,10 +101,10 @@ runs:
         path: docs/*.txt
 
     - name: "Zip Documentation"
-      shell: bash
-      run: |
-        ls docs/
-        7z a -tzip docs/archive/doc-${{inputs.PACKAGE_NAME}}.zip docs/build
+      uses: vimtor/action-zip@v1
+      with:
+        files: docs/build
+        dest: docs/archive/doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Upload Documentation"
       uses: actions/upload-artifact@v2

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -34,7 +34,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.0
+      uses: pyansys/pydpf-actions/install-dpf-server@v2.1
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -89,7 +89,7 @@ runs:
     - name: "Build PDF Documentation"
       shell: bash
       working-directory: docs
-      if: ${{ inputs.generate_pdf }} == "True"
+      if: ${{ inputs.generate_pdf == 'True' }}
       run: |
         export TEMP=${{ runner.temp }}
         echo "Making pdf doc..."

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -71,9 +71,7 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html 
-
-#        &>log_html.txt
+        make html &>log_html.txt
 
     - name: "Build PDF Documentation"
       shell: bash
@@ -82,10 +80,10 @@ runs:
         export TEMP=${{ runner.temp }}
         sudo apt update
         sudo apt install texlive-latex-extra latexmk
-        make clean
         echo "Making pdf doc..."
         make pdf 
 
+#        make clean
 #        &>log_pdf.txt
 
     - name: "Upload Documentation Build log"

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -24,6 +24,10 @@ inputs:
   build_extras:
     description: "Extra paths to build the doc for in the spinx-api command"
     required: false
+  generate_pdf:
+    description: "Whether to generate the PDF doc"
+    required: false
+    default: "True"
 
 runs:
   using: "composite"
@@ -80,19 +84,16 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html 
-
-#        &>log_html.txt
+        make html &>log_html.txt
 
     - name: "Build PDF Documentation"
       shell: bash
       working-directory: docs
+      if: ${{ inputs.generate_pdf }} == "True"
       run: |
         export TEMP=${{ runner.temp }}
         echo "Making pdf doc..."
-        make pdf 
-
-#        &>log_pdf.txt
+        make pdf &>log_pdf.txt
 
     - name: "Upload Documentation Build log"
       uses: actions/upload-artifact@v2

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -70,7 +70,9 @@ runs:
       run: |
         make clean
         echo "Making html doc..."
-        make html &>log_html.txt
+        make html 
+
+#        &>log_html.txt
 
     - name: "Build PDF Documentation"
       shell: bash
@@ -80,7 +82,9 @@ runs:
         sudo apt install texlive-latex-extra latexmk
         make clean
         echo "Making pdf doc..."
-        make pdf &>log_pdf.txt
+        make pdf 
+
+#        &>log_pdf.txt
 
     - name: "Upload Documentation Build log"
       uses: actions/upload-artifact@v2

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -112,7 +112,7 @@ runs:
       with:
         name: doc-${{inputs.PACKAGE_NAME}}-log
         path: docs/*.txt
-      if: always()
+      if: inputs.debug == 'false'
 
     - name: "Zip HTML Documentation"
       uses: vimtor/action-zip@v1

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -81,10 +81,7 @@ runs:
         sudo apt update
         sudo apt install texlive-latex-extra latexmk
         echo "Making pdf doc..."
-        make pdf 
-
-#        make clean
-#        &>log_pdf.txt
+        make pdf &>log_pdf.txt
 
     - name: "Upload Documentation Build log"
       uses: actions/upload-artifact@v2

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
       run: |
         export SPHINX_APIDOC_OPTIONS=inherited-members
-        sphinx-apidoc -o docs/source/api ansys -f --implicit-namespaces --separate --no-headings
+        sphinx-apidoc -o docs/source/api ansys -f --implicit-namespaces --separate --no-headings &>log_sphinx.txt
 
     - name: "Build HTML Documentation"
       shell: bash
@@ -71,7 +71,9 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html &>log_html.txt
+        make html 
+
+#        &>log_html.txt
 
     - name: "Build PDF Documentation"
       shell: bash
@@ -81,7 +83,9 @@ runs:
         sudo apt update
         sudo apt install texlive-latex-extra latexmk
         echo "Making pdf doc..."
-        make pdf &>log_pdf.txt
+        make pdf 
+
+#        &>log_pdf.txt
 
     - name: "Upload Documentation Build log"
       uses: actions/upload-artifact@v2

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -44,13 +44,13 @@ runs:
         sudo apt install pandoc texlive-latex-extra latexmk
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.2
+      uses: pyansys/pydpf-actions/install-dpf-server@v2.2.dev1
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
     - name: "Install local package"
-      uses: pyansys/pydpf-actions/install-package@v2.2
+      uses: pyansys/pydpf-actions/install-package@v2.2.dev1
 
     - name: "Install extras"
       shell: bash
@@ -96,22 +96,24 @@ runs:
         make pdf &>log_pdf.txt
 
     - name: "Upload Documentation Build log"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: doc-${{inputs.PACKAGE_NAME}}-log
         path: docs/*.txt
+      if: always()
 
-    - name: "Zip Documentation"
-      uses: vimtor/action-zip@v1
+    - name: "Upload HTML Documentation"
+      uses: actions/upload-artifact@v3
       with:
-        files: docs/build
-        dest: docs/archive/doc-${{inputs.PACKAGE_NAME}}.zip
+        name: HTML-doc-${{inputs.PACKAGE_NAME}}
+        path: ./docs/build/html/*
 
-    - name: "Upload Documentation"
-      uses: actions/upload-artifact@v2
+    - name: "Upload PDF Documentation"
+      uses: actions/upload-artifact@v3
+      if: ${{ inputs.generate_pdf == 'True' }}
       with:
-        name: doc-${{inputs.PACKAGE_NAME}}
-        path: docs/archive/doc-${{inputs.PACKAGE_NAME}}.zip
+        name: PDF-doc-${{inputs.PACKAGE_NAME}}
+        path: ./docs/build/latex/*.pdf
 
     - name: "Kill all servers"
-      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -102,18 +102,30 @@ runs:
         path: docs/*.txt
       if: always()
 
+    - name: "Zip HTML Documentation"
+      uses: vimtor/action-zip@v1
+      with:
+        files: ./docs/build/html/*
+        dest: HTML-doc-${{inputs.PACKAGE_NAME}}.zip
+
     - name: "Upload HTML Documentation"
       uses: actions/upload-artifact@v3
       with:
         name: HTML-doc-${{inputs.PACKAGE_NAME}}
-        path: ./docs/build/html/*
+        path: HTML-doc-${{inputs.PACKAGE_NAME}}.zip
+
+    - name: "Zip PDF Documentation"
+      uses: vimtor/action-zip@v1
+      with:
+        files: ./docs/build/latex/*.pdf
+        dest: PDF-doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Upload PDF Documentation"
       uses: actions/upload-artifact@v3
       if: ${{ inputs.generate_pdf == 'True' }}
       with:
         name: PDF-doc-${{inputs.PACKAGE_NAME}}
-        path: ./docs/build/latex/*.pdf
+        path: PDF-doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: "Test import"
       shell: bash
       working-directory: tests
-      run: python -c "from ansys.dpf import ${{inputs.MODULE}}; print(${{inputs.MODULE}}.Report(gpu=False))"
+      run: python -c "from ansys.dpf import ${{inputs.MODULE}}"
 
     - name: "Setup headless display"
       uses: pyvista/setup-headless-display-action@v1

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -44,7 +44,7 @@ runs:
         sudo apt install pandoc texlive-latex-extra latexmk
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.1
+      uses: pyansys/pydpf-actions/install-dpf-server@v2.2
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -74,7 +74,9 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html &>log_html.txt
+        make html 
+
+#        &>log_html.txt
 
     - name: "Build PDF Documentation"
       shell: bash

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -71,9 +71,7 @@ runs:
         export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
-        make html 
-
-#        &>log_html.txt
+        make html &>log_html.txt
 
     - name: "Build PDF Documentation"
       shell: bash
@@ -83,9 +81,7 @@ runs:
         sudo apt update
         sudo apt install texlive-latex-extra latexmk
         echo "Making pdf doc..."
-        make pdf 
-
-#        &>log_pdf.txt
+        make pdf &>log_pdf.txt
 
     - name: "Upload Documentation Build log"
       uses: actions/upload-artifact@v2

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -68,6 +68,7 @@ runs:
       shell: bash
       working-directory: docs
       run: |
+        export TEMP=${{ runner.temp }}
         make clean
         echo "Making html doc..."
         make html 
@@ -78,6 +79,7 @@ runs:
       shell: bash
       working-directory: docs
       run: |
+        export TEMP=${{ runner.temp }}
         sudo apt update
         sudo apt install texlive-latex-extra latexmk
         make clean

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -44,13 +44,13 @@ runs:
         sudo apt install pandoc texlive-latex-extra latexmk
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.2.dev1
+      uses: pyansys/pydpf-actions/install-dpf-server@feat/use_build
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
     - name: "Install local package"
-      uses: pyansys/pydpf-actions/install-package@v2.2.dev1
+      uses: pyansys/pydpf-actions/install-package@feat/use_build
 
     - name: "Install extras"
       shell: bash
@@ -140,4 +140,4 @@ runs:
         path: PDF-doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Kill all servers"
-      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2.dev1
+      uses: pyansys/pydpf-actions/kill-dpf-servers@feat/use_build

--- a/build_doc/action.yml
+++ b/build_doc/action.yml
@@ -50,7 +50,7 @@ runs:
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
     - name: "Install local package"
-      uses: pyansys/pydpf-actions/install-package@v2.0
+      uses: pyansys/pydpf-actions/install-package@v2.2
 
     - name: "Install extras"
       shell: bash
@@ -114,4 +114,4 @@ runs:
         path: docs/archive/doc-${{inputs.PACKAGE_NAME}}.zip
 
     - name: "Kill all servers"
-      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -50,7 +50,7 @@ runs:
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
     - name: "Install local package"
-      uses: pyansys/pydpf-actions/install-package@v2.2.dev1
+      uses: pyansys/pydpf-actions/install-package@feat/use_build
       with:
         extra-pip-args: ${{inputs.extra-pip-args}}
 

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -34,11 +34,6 @@ inputs:
     required: true
     default: "true"
 
-outputs:
-  SERVER:
-    description: "Path to the server"
-    value: ${{ steps.set-server-path.outputs.server-path }}
-
 runs:
   using: "composite"
   steps:

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'
       shell: bash
-      working-directory: .github/workflows
+      working-directory: '.github\workflows'
       run: |
         pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
         pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -39,7 +39,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.2
+      uses: pyansys/pydpf-actions/install-dpf-server@v2.2.1
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -21,6 +21,10 @@ inputs:
   install_extras:
     description: "Extras to install for the local package"
     required: false
+  extra-pip-args:
+    description: "Args given to pip install command"
+    default: ""
+    type: string
   wheelhouse:
     description: "Whether to generate a wheelhouse"
     required: true
@@ -44,27 +48,9 @@ runs:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
-    - name: "Install gatebin Windows"
-      if: runner.os == 'Windows'
-      shell: bash
-      working-directory: .github\workflows
-      run: pip install ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
-
-    - name: "Install gatebin Linux"
-      if: runner.os == 'Linux'
-      shell: bash
-      working-directory: .github\workflows
-      run: pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
-
-    - name: "Install pygate"
-      shell: bash
-      working-directory: .github\workflows
-      run: |
-        pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
-        pip install ansys_grpc_dpf-0.5.dev1-py3-none-any.whl
-
     - name: "Install local package"
       uses: pyansys/pydpf-actions/install-package@v2.2
+      extra-pip-args: ${{inputs.extra-pip-args}}
 
     - name: "Install extras"
       shell: bash

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -21,6 +21,14 @@ inputs:
   install_extras:
     description: "Extras to install for the local package"
     required: false
+  wheelhouse:
+    description: "Whether to generate a wheelhouse"
+    required: false
+    default: "false"
+  wheel:
+    description: "Whether to upload the wheel"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -80,28 +88,31 @@ runs:
       id: version
 
     - name: "Upload wheel to artifacts"
+      if: ${{ inputs.wheel }} == "true"
       uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}_wheel
         path: ./dist/*
-      if: ${{ inputs.python-version }} == '3.8' && ${{ runner.os }} == 'Windows'
 
-#    - name: Generate wheelhouse
-#      shell: bash
-#      run: pip wheel . -w wheelhouse
-#
-#    - name: Zip wheelhouse
-#      uses: vimtor/action-zip@v1
-#      with:
-#        files: wheelhouse
-#        dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
-#
-#    - name: Upload wheelhouse to artifacts
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}
-#        path: '*.zip'
-#        retention-days: 7
+    - name: "Generate wheelhouse"
+      if: ${{ inputs.wheelhouse }} != "false"
+      shell: bash
+      run: pip wheel . -w wheelhouse
+
+    - name: "Zip wheelhouse"
+      if: ${{ inputs.wheelhouse }} != "false"
+      uses: vimtor/action-zip@v1
+      with:
+        files: wheelhouse
+        dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
+
+    - name: "Upload wheelhouse to artifacts"
+      if: ${{ inputs.wheelhouse }} != "false"
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}
+        path: '*.zip'
+        retention-days: 7
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -84,22 +84,22 @@ runs:
         path: ./dist/*
       if: ${{ inputs.python-version }} == '3.8' && ${{ runner.os }} == 'Windows'
 
-    - name: Generate wheelhouse
-      shell: bash
-      run: pip wheel . -w wheelhouse
-
-    - name: Zip wheelhouse
-      uses: vimtor/action-zip@v1
-      with:
-        files: wheelhouse
-        dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
-
-    - name: Upload wheelhouse to artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}
-        path: '*.zip'
-        retention-days: 7
+#    - name: Generate wheelhouse
+#      shell: bash
+#      run: pip wheel . -w wheelhouse
+#
+#    - name: Zip wheelhouse
+#      uses: vimtor/action-zip@v1
+#      with:
+#        files: wheelhouse
+#        dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
+#
+#    - name: Upload wheelhouse to artifacts
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}
+#        path: '*.zip'
+#        retention-days: 7
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -48,18 +48,17 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       working-directory: .github\workflows
-      run: pip install ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
+      run: |
+        pip install ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
+        pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
+        pip install ansys_grpc_dpf-0.5.dev1-py3-none-any.whl
 
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'
       shell: bash
       working-directory: .github/workflows
-      run: pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
-
-    - name: "Install pygate"
-      shell: bash
-      working-directory: .github\workflows
       run: |
+        pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
         pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
         pip install ansys_grpc_dpf-0.5.dev1-py3-none-any.whl
 

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'
       shell: bash
-      working-directory: .github\workflows
+      working-directory: .github/workflows
       run: pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
 
     - name: "Install pygate"

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -39,7 +39,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.2.1
+      uses: pyansys/pydpf-actions/install-dpf-server@v2.2
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -67,5 +67,22 @@ runs:
         path: ./dist/*
       if: ${{ inputs.python-version }} == '3.8' && ${{ runner.os }} == 'Windows'
 
+    - name: Generate wheelhouse
+      shell: bash
+      run: pip wheel . -w wheelhouse
+
+    - name: Zip wheelhouse
+      uses: vimtor/action-zip@v1
+      with:
+        files: wheelhouse
+        dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
+
+    - name: Upload wheelhouse to artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}
+        path: '*.zip'
+        retention-days: 7
+
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -49,7 +49,7 @@ runs:
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
     - name: "Install local package"
-      uses: pyansys/pydpf-actions/install-package@v2.2
+      uses: pyansys/pydpf-actions/install-package@v2.2.dev1
       extra-pip-args: ${{inputs.extra-pip-args}}
 
     - name: "Install extras"

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'
       shell: bash
-      working-directory: '.github\workflows'
+      working-directory: .github/workflows
       run: |
         pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
         pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -39,12 +39,12 @@ runs:
     - name: "Install gatebin Windows"
       if: runner.os == 'Windows'
       shell: bash
-      run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
+      run: pip install ./.github/workflows/ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
 
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'
       shell: bash
-      run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
+      run: pip install ./.github/workflows/ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
 
     - name: "Install pygate"
       shell: bash

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -23,11 +23,11 @@ inputs:
     required: false
   wheelhouse:
     description: "Whether to generate a wheelhouse"
-    required: false
+    required: true
     default: "false"
   wheel:
     description: "Whether to upload the wheel"
-    required: false
+    required: true
     default: "true"
 
 runs:
@@ -95,19 +95,19 @@ runs:
         path: ./dist/*
 
     - name: "Generate wheelhouse"
-      if: ${{ inputs.wheelhouse }} != "false"
+      if: ${{ inputs.wheelhouse }} == "true"
       shell: bash
       run: pip wheel . -w wheelhouse
 
     - name: "Zip wheelhouse"
-      if: ${{ inputs.wheelhouse }} != "false"
+      if: ${{ inputs.wheelhouse }} == "true"
       uses: vimtor/action-zip@v1
       with:
         files: wheelhouse
         dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
 
     - name: "Upload wheelhouse to artifacts"
-      if: ${{ inputs.wheelhouse }} != "false"
+      if: ${{ inputs.wheelhouse }} == "true"
       uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -51,7 +51,7 @@ runs:
       run: |
         pip install ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
         pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
-        pip install ansys_grpc_dpf-0.5.dev1-py3-none-any.whl
+        pip install ansys_grpc_dpf-0.5.1-py3-none-any.whl
 
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'
@@ -60,7 +60,7 @@ runs:
       run: |
         pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
         pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
-        pip install ansys_grpc_dpf-0.5.dev1-py3-none-any.whl
+        pip install ansys_grpc_dpf-0.5.1-py3-none-any.whl
 
     - name: "Install local package"
       uses: pyansys/pydpf-actions/install-package@v2.2

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -37,12 +37,12 @@ runs:
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
     - name: "Install gatebin Windows"
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
       shell: bash
       run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
 
     - name: "Install gatebin Linux"
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       shell: bash
       run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
 

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -38,13 +38,16 @@ runs:
 
     - name: "Install gatebin Windows"
       if: matrix.os == 'windows-latest'
+      shell: bash
       run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
 
     - name: "Install gatebin Linux"
       if: matrix.os == 'ubuntu-latest'
+      shell: bash
       run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
 
     - name: "Install pygate"
+      shell: bash
       run: pip install .\.github\workflows\ansys_dpf_gate-0.1.dev1-py3-none-any.whl
 
     - name: "Install local package"

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -70,7 +70,7 @@ runs:
     - name: "Test import"
       shell: bash
       working-directory: tests
-      run: python -c "from ansys.dpf import ${{inputs.MODULE}}; print(${{inputs.MODULE}}.Report(gpu=False))"
+      run: python -c "from ansys.dpf import ${{inputs.MODULE}}"
 
     - name: "Retrieve package version"
       shell: bash

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -31,7 +31,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.0
+      uses: pyansys/pydpf-actions/install-dpf-server@v2.1
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -51,7 +51,9 @@ runs:
     - name: "Install pygate"
       shell: bash
       working-directory: .github\workflows
-      run: pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
+      run: |
+        pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
+        pip install ansys_grpc_dpf-0.5.dev1-py3-none-any.whl
 
     - name: "Install local package"
       uses: pyansys/pydpf-actions/install-package@v2.0

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -88,26 +88,26 @@ runs:
       id: version
 
     - name: "Upload wheel to artifacts"
-      if: ${{ inputs.wheel }} == "true"
+      if: inputs.wheel == true
       uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}_wheel
         path: ./dist/*
 
     - name: "Generate wheelhouse"
-      if: ${{ inputs.wheelhouse }} == "true"
+      if: inputs.wheelhouse == true
       shell: bash
       run: pip wheel . -w wheelhouse
 
     - name: "Zip wheelhouse"
-      if: ${{ inputs.wheelhouse }} == "true"
+      if: inputs.wheelhouse == true
       uses: vimtor/action-zip@v1
       with:
         files: wheelhouse
         dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
 
     - name: "Upload wheelhouse to artifacts"
-      if: ${{ inputs.wheelhouse }} == "true"
+      if: inputs.wheelhouse == true
       uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -38,8 +38,8 @@ runs:
 
     - name: "Install gatebin Windows"
       if: runner.os == 'Windows'
-      shell: bash
-      run: pip install ./.github/workflows/ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
+      shell: pwsh
+      run: pip install .github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
 
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -34,6 +34,11 @@ inputs:
     required: true
     default: "true"
 
+outputs:
+  SERVER:
+    description: "Path to the server"
+    value: ${{ steps.set-server-path.outputs.server-path }}
+
 runs:
   using: "composite"
   steps:
@@ -43,6 +48,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: "Install DPF"
+      id: set-server-path
       uses: pyansys/pydpf-actions/install-dpf-server@v2.2
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -31,7 +31,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: "Install DPF"
-      uses: pyansys/pydpf-actions/install-dpf-server@v2.1
+      uses: pyansys/pydpf-actions/install-dpf-server@v2.2
       with:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -38,17 +38,20 @@ runs:
 
     - name: "Install gatebin Windows"
       if: runner.os == 'Windows'
-      shell: pwsh
-      run: pip install .github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
+      shell: bash
+      working-directory: .github\workflows
+      run: pip install ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
 
     - name: "Install gatebin Linux"
       if: runner.os == 'Linux'
       shell: bash
-      run: pip install ./.github/workflows/ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
+      working-directory: .github\workflows
+      run: pip install ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
 
     - name: "Install pygate"
       shell: bash
-      run: pip install .\.github\workflows\ansys_dpf_gate-0.1.dev1-py3-none-any.whl
+      working-directory: .github\workflows
+      run: pip install ansys_dpf_gate-0.1.dev1-py3-none-any.whl
 
     - name: "Install local package"
       uses: pyansys/pydpf-actions/install-package@v2.0

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -56,7 +56,7 @@ runs:
         pip install ansys_grpc_dpf-0.5.dev1-py3-none-any.whl
 
     - name: "Install local package"
-      uses: pyansys/pydpf-actions/install-package@v2.0
+      uses: pyansys/pydpf-actions/install-package@v2.2
 
     - name: "Install extras"
       shell: bash
@@ -65,7 +65,7 @@ runs:
       if: ${{inputs.install_extras}} != null
 
     - name: "Check licences of packages"
-      uses: pyansys/pydpf-actions/check-licenses@v2.0
+      uses: pyansys/pydpf-actions/check-licenses@v2.2
 
     - name: "Test import"
       shell: bash
@@ -104,4 +104,4 @@ runs:
 #        retention-days: 7
 
     - name: "Kill all servers"
-      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -36,6 +36,17 @@ runs:
         dpf-standalone-TOKEN: ${{inputs.dpf-standalone-TOKEN}}
         ANSYS_VERSION : ${{inputs.ANSYS_VERSION}}
 
+    - name: "Install gatebin Windows"
+      if: matrix.os == 'windows-latest'
+      run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-win_amd64.whl
+
+    - name: "Install gatebin Linux"
+      if: matrix.os == 'ubuntu-latest'
+      run: pip install .\.github\workflows\ansys_dpf_gatebin-0.1.dev1-py3-none-linux_x86_64.whl
+
+    - name: "Install pygate"
+      run: pip install .\.github\workflows\ansys_dpf_gate-0.1.dev1-py3-none-any.whl
+
     - name: "Install local package"
       uses: pyansys/pydpf-actions/install-package@v2.0
 

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -88,26 +88,26 @@ runs:
       id: version
 
     - name: "Upload wheel to artifacts"
-      if: inputs.wheel == true
+      if: inputs.wheel == 'true'
       uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}_wheel
         path: ./dist/*
 
     - name: "Generate wheelhouse"
-      if: inputs.wheelhouse == true
+      if: inputs.wheelhouse == 'true'
       shell: bash
       run: pip wheel . -w wheelhouse
 
     - name: "Zip wheelhouse"
-      if: inputs.wheelhouse == true
+      if: inputs.wheelhouse == 'true'
       uses: vimtor/action-zip@v1
       with:
         files: wheelhouse
         dest: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}.zip
 
     - name: "Upload wheelhouse to artifacts"
-      if: inputs.wheelhouse == true
+      if: inputs.wheelhouse == 'true'
       uses: actions/upload-artifact@v2
       with:
         name: ${{ inputs.PACKAGE_NAME }}-v${{ steps.version.outputs.VERSION }}-wheelhouse-${{ runner.os }}-${{ inputs.python-version }}

--- a/build_package/action.yml
+++ b/build_package/action.yml
@@ -50,7 +50,8 @@ runs:
 
     - name: "Install local package"
       uses: pyansys/pydpf-actions/install-package@v2.2.dev1
-      extra-pip-args: ${{inputs.extra-pip-args}}
+      with:
+        extra-pip-args: ${{inputs.extra-pip-args}}
 
     - name: "Install extras"
       shell: bash

--- a/install-dpf-server/action.yml
+++ b/install-dpf-server/action.yml
@@ -41,7 +41,7 @@ runs:
           echo "::set-output name=server-path::$(echo ${SERVER})"
       shell: bash
 
-    - run: echo "AWP_ROOT${{inputs.ANSYS_VERSION}}=${{env.SERVER}}"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+    - run: echo "ANSYS_DPF_PATH=${{env.SERVER}}"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       shell: pwsh
 
     - run: |

--- a/install-dpf-server/action.yml
+++ b/install-dpf-server/action.yml
@@ -21,17 +21,17 @@ runs:
         $TEMP2 = $TEMP.ToString()
         $ANSYS_VERSION_WITH_POINT=$TEMP2.Insert(2,".")
         $BranchName = if ("${{runner.os}}" -eq "Linux") { "linux_release-$ANSYS_VERSION_WITH_POINT" } else { "win_release-$ANSYS_VERSION_WITH_POINT" }
-        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone -C v${{inputs.ANSYS_VERSION}}
+        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone dpf-standalone/v${{inputs.ANSYS_VERSION}}
       shell: pwsh
       
     - run: |
           if ("${{runner.os}}" -eq "Linux")
           {
-            echo "SERVER=${{github.workspace}}/v${{inputs.ANSYS_VERSION}}/dpf-standalone"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+            echo "SERVER=${{github.workspace}}/dpf-standalone/v${{inputs.ANSYS_VERSION}}"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
           else
           {
-            echo "SERVER=${{github.workspace}}\v${{inputs.ANSYS_VERSION}}\dpf-standalone"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+            echo "SERVER=${{github.workspace}}\dpf-standalone\v${{inputs.ANSYS_VERSION}}"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
            
       shell: pwsh

--- a/install-dpf-server/action.yml
+++ b/install-dpf-server/action.yml
@@ -21,17 +21,17 @@ runs:
         $TEMP2 = $TEMP.ToString()
         $ANSYS_VERSION_WITH_POINT=$TEMP2.Insert(2,".")
         $BranchName = if ("${{runner.os}}" -eq "Linux") { "linux_release-$ANSYS_VERSION_WITH_POINT" } else { "win_release-$ANSYS_VERSION_WITH_POINT" }
-        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone
+        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone -C v${{inputs.ANSYS_VERSION}}
       shell: pwsh
       
     - run: |
           if ("${{runner.os}}" -eq "Linux")
           {
-            echo "SERVER=${{github.workspace}}/dpf-standalone"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+            echo "SERVER=${{github.workspace}}/v${{inputs.ANSYS_VERSION}}/dpf-standalone"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
           else
           {
-            echo "SERVER=${{github.workspace}}\dpf-standalone"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+            echo "SERVER=${{github.workspace}}\v${{inputs.ANSYS_VERSION}}\dpf-standalone"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
            
       shell: pwsh

--- a/install-dpf-server/action.yml
+++ b/install-dpf-server/action.yml
@@ -41,7 +41,7 @@ runs:
           echo "::set-output name=server-path::$(echo ${SERVER})"
       shell: bash
 
-    - run: echo "ANSYS_DPF_PATH=${{env.SERVER}}"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+    - run: echo "AWP_ROOT${{inputs.ANSYS_VERSION}}=${{env.SERVER}}"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       shell: pwsh
 
     - run: |

--- a/install-dpf-server/action.yml
+++ b/install-dpf-server/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - run: |
         echo ${{runner.os}}
-        $TEMP = ${{env.ANSYS_VERSION}}
+        $TEMP = ${{inputs.ANSYS_VERSION}}
         $TEMP2 = $TEMP.ToString()
         $ANSYS_VERSION_WITH_POINT=$TEMP2.Insert(2,".")
         $BranchName = if ("${{runner.os}}" -eq "Linux") { "linux_release-$ANSYS_VERSION_WITH_POINT" } else { "win_release-$ANSYS_VERSION_WITH_POINT" }

--- a/install-package/action.yml
+++ b/install-package/action.yml
@@ -1,6 +1,11 @@
 name: "Install package"
 description: "Installs the local package using requirements_build.txt and setup.py while 
 creating a wheel"
+inputs:
+  extra-pip-args:
+    description: "Args given to pip install command"
+    default: ""
+    type: string
 runs:
   using: "composite"
   steps:
@@ -11,5 +16,5 @@ runs:
         python setup.py bdist_wheel
         export WHEEL_NAME=`ls dist/*.whl`
         echo ${WHEEL_NAME}
-        pip install ${WHEEL_NAME}
+        pip install ${WHEEL_NAME} ${{ inputs.extra-pip-args }}
         cd tests

--- a/install-package/action.yml
+++ b/install-package/action.yml
@@ -6,6 +6,8 @@ inputs:
     description: "Args given to pip install command"
     default: ""
     type: string
+    required: false
+
 runs:
   using: "composite"
   steps:

--- a/install-package/action.yml
+++ b/install-package/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: "Install local package"
       shell: bash
       run: |
-        pip install -r requirements_build.txt
+        pip install -r requirements/requirements_build.txt
         python setup.py bdist_wheel
         export WHEEL_NAME=`ls dist/*.whl`
         echo ${WHEEL_NAME}

--- a/install-package/action.yml
+++ b/install-package/action.yml
@@ -1,14 +1,13 @@
 name: "Install package"
-description: "Installs the local package using requirements_build.txt and setup.py while 
-creating a wheel"
+description: "Installs the local package using the build library."
 runs:
   using: "composite"
   steps:
     - name: "Install local package"
       shell: bash
       run: |
-        pip install -r requirements_build.txt
-        python setup.py bdist_wheel
+        pip install build
+        python -m build --wheel
         export WHEEL_NAME=`ls dist/*.whl`
         echo ${WHEEL_NAME}
         pip install ${WHEEL_NAME}

--- a/kill-dpf-servers/action.yml
+++ b/kill-dpf-servers/action.yml
@@ -8,7 +8,10 @@ runs:
       run: |
         import psutil
         proc_name = "Ans.Dpf.Grpc"
+        nb_procs = 0
         for proc in psutil.process_iter():
             # check whether the process name matches
             if proc_name in proc.name():
                 proc.kill()
+                nb_procs += 1
+        print(f"Killed {nb_procs} {proc_name} processes.")

--- a/kill-dpf-servers/action.yml
+++ b/kill-dpf-servers/action.yml
@@ -4,10 +4,11 @@ runs:
   using: "composite"
   steps:
     - name: "Kill all servers"
-      shell: bash
+      shell: python
       run: |
-        echo $0
-        if pgrep -x "Ans.Dpf.Grpc" > /dev/null
-        then
-            pkill -f Ans.Dpf.Grpc.exe || true
-        fi        
+        import psutil
+        proc_name = "Ans.Dpf.Grpc"
+        for proc in psutil.process_iter():
+            # check whether the process name matches
+            if proc_name in proc.name():
+                proc.kill()

--- a/prepare_tests/action.yml
+++ b/prepare_tests/action.yml
@@ -16,12 +16,15 @@ runs:
     - name: "Set working directory"
       shell: bash
       run: |
+        echo ${{ inputs.working-directory }}
         cd ${{ inputs.working-directory }}
+        ls
 
     - name: "Setup headless display"
       uses: pyvista/setup-headless-display-action@v1
 
     - name: "Install Test Environment"
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         pip install -r requirements/requirements_test.txt

--- a/prepare_tests/action.yml
+++ b/prepare_tests/action.yml
@@ -1,0 +1,31 @@
+name: "Prepare Testing environment for DPF Package"
+description: "Prepare Testing environment for DPF Package"
+inputs:
+  DEBUG:
+    description: "Debug print mode"
+    required: true
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup headless display"
+      uses: pyvista/setup-headless-display-action@v1
+
+    - name: "Install Test Environment"
+      shell: bash
+      run: |
+        pip install -r requirements/requirements_test.txt
+
+    - name: "Set TMP"
+      shell: bash
+      run: |
+        echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
+        echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
+      if: runner.os == 'Linux'
+
+    - name: "Debug mode"
+      shell: bash
+      if: inputs.DEBUG == 'true'
+      run: |
+        echo "DEBUG=-v --durations=10 --durations-min=1.0" >> $GITHUB_ENV

--- a/prepare_tests/action.yml
+++ b/prepare_tests/action.yml
@@ -5,10 +5,19 @@ inputs:
     description: "Debug print mode"
     required: true
     default: "false"
+  working-directory:
+    description: "Working-directory"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
   steps:
+    - name: "Set working directory"
+      shell: bash
+      run: |
+        cd ${{ inputs.working-directory }}
+
     - name: "Setup headless display"
       uses: pyvista/setup-headless-display-action@v1
 

--- a/push_doc/action.yml
+++ b/push_doc/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Commit Doc to release branch"
+    - name: "Create a commit"
       shell: pwsh
       run: |
         cd docs/build/html
@@ -26,7 +26,7 @@ runs:
         GH_DOC_BRANCH: gh-pages
         GH_EMAIL: pyansys.github.bot@ansys.com
 
-    - name: "Push Doc to pyansys/DPF-Post-docs"
+    - name: "Push commit to the documentation repository"
       shell: bash
       run: |
         cd docs/build/html

--- a/release_package/action.yml
+++ b/release_package/action.yml
@@ -4,6 +4,10 @@ inputs:
   PYPI_TOKEN:
     description: "PyPi token to the package repository"
     required: true
+  TEST:
+    description: "Whether this is a test release to TestPyPi"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -29,16 +33,29 @@ runs:
       shell: bash
       run: python setup.py sdist
 
-    - name: Publish distribution 📦 to PyPI
+    - name: Publish distribution 📦 to TestPyPI
       shell: bash
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ inputs.PYPI_TOKEN }}
-        TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+        TWINE_REPOSITORY_URL: "https://test.pypi.org/simple/"
+      if: ${{ inputs.TEST == "true"}}
       run: |
         twine upload --skip-existing ./**/*.whl
         twine upload --skip-existing ./**/*.tar.gz
 #         /!\ Do NOT publish to Pypi the zip containing the wheelhouses
+
+#    - name: Publish distribution 📦 to PyPI
+#      shell: bash
+#      env:
+#        TWINE_USERNAME: __token__
+#        TWINE_PASSWORD: ${{ inputs.PYPI_TOKEN }}
+#        TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+#      if: ${{ inputs.TEST == "false"}}
+#      run: |
+#        twine upload --skip-existing ./**/*.whl
+#        twine upload --skip-existing ./**/*.tar.gz
+##         /!\ Do NOT publish to Pypi the zip containing the wheelhouses
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/release_package/action.yml
+++ b/release_package/action.yml
@@ -29,33 +29,9 @@ runs:
         python -m pip install --upgrade pip
         pip install setuptools twine
 
-    - name: Build package
-      shell: bash
-      run: python setup.py sdist
-
-    - name: Publish distribution 📦 to TestPyPI
-      shell: bash
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ inputs.PYPI_TOKEN }}
-        TWINE_REPOSITORY_URL: "https://test.pypi.org/simple/"
-      if: ${{ inputs.TEST == "true"}}
-      run: |
-        twine upload --skip-existing ./**/*.whl
-        twine upload --skip-existing ./**/*.tar.gz
-#         /!\ Do NOT publish to Pypi the zip containing the wheelhouses
-
-#    - name: Publish distribution 📦 to PyPI
+#    - name: Build package
 #      shell: bash
-#      env:
-#        TWINE_USERNAME: __token__
-#        TWINE_PASSWORD: ${{ inputs.PYPI_TOKEN }}
-#        TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
-#      if: ${{ inputs.TEST == "false"}}
-#      run: |
-#        twine upload --skip-existing ./**/*.whl
-#        twine upload --skip-existing ./**/*.tar.gz
-##         /!\ Do NOT publish to Pypi the zip containing the wheelhouses
+#      run: python setup.py sdist
 
     - name: Release
       uses: softprops/action-gh-release@v1
@@ -65,3 +41,27 @@ runs:
           ./**/*.tar.gz
           ./**/*.pdf
           ./**/*.zip
+
+    - name: Publish distribution 📦 to TestPyPI
+      shell: bash
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ inputs.PYPI_TOKEN }}
+        TWINE_REPOSITORY_URL: "https://test.pypi.org/simple/"
+      if: inputs.TEST == 'true'
+      run: |
+        twine upload --skip-existing ./**/*.whl
+        twine upload --skip-existing ./**/*.tar.gz
+#         /!\ Do NOT publish to Pypi the zip containing the wheelhouses
+
+    - name: Publish distribution 📦 to PyPI
+      shell: bash
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ inputs.PYPI_TOKEN }}
+        TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+      if: inputs.TEST == 'false'
+      run: |
+        twine upload --skip-existing ./**/*.whl
+        twine upload --skip-existing ./**/*.tar.gz
+#         /!\ Do NOT publish to Pypi the zip containing the wheelhouses

--- a/test_api/action.yml
+++ b/test_api/action.yml
@@ -1,0 +1,24 @@
+name: "Test API of DPF Package"
+description: "Test API of DPF Package"
+inputs:
+  MODULE:
+    description: "Module name"
+    required: true
+    default: post
+  PACKAGE_NAME:
+    description: "Package name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Test API"
+      shell: bash
+      run: |
+        cd tests
+        echo "TMP: "$TMP
+        echo "TEMP: "$TEMP
+        pytest $DEBUG --cov=ansys.dpf.${{inputs.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+
+    - name: "Kill all servers"
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/test_docstrings/action.yml
+++ b/test_docstrings/action.yml
@@ -8,10 +8,19 @@ inputs:
   PACKAGE_NAME:
     description: "Package name"
     required: true
+  working-directory:
+    description: "Working-directory"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
   steps:
+    - name: "Set working directory"
+      shell: bash
+      run: |
+        cd ${{ inputs.working-directory }}
+
     - name: "Test API Docstrings"
       shell: bash
       run: |

--- a/test_docstrings/action.yml
+++ b/test_docstrings/action.yml
@@ -17,7 +17,7 @@ runs:
       run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
+        pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml src/ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/test_docstrings/action.yml
+++ b/test_docstrings/action.yml
@@ -19,9 +19,12 @@ runs:
     - name: "Set working directory"
       shell: bash
       run: |
+        echo ${{ inputs.working-directory }}
         cd ${{ inputs.working-directory }}
+        ls
 
     - name: "Test API Docstrings"
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo "TMP: "$TMP

--- a/test_docstrings/action.yml
+++ b/test_docstrings/action.yml
@@ -1,0 +1,29 @@
+name: "Test docstrings of DPF Package"
+description: "Test docstrings of DPF Package"
+inputs:
+  MODULE:
+    description: "Module name"
+    required: true
+    default: post
+  PACKAGE_NAME:
+    description: "Package name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Test API Docstrings"
+      shell: bash
+      run: |
+        echo "TMP: "$TMP
+        echo "TEMP: "$TEMP
+        pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
+
+    - name: "Kill all servers"
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
+
+    - name: "Upload Docstring Test Results"
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.PACKAGE_NAME }}_doctest
+        path: junit/test-doctests-results.xml

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -37,11 +37,10 @@ runs:
 #      if: ${{ runner.os }} == "Linux"
 
     - name: "Test API"
-      shell: bash
+      shell: pwsh
       run: |
         cd tests
-        echo ${{ runner.temp }} | sed -e 's/\/\\/g'
-        export TEMP=${{ runner.temp }}
+        $env:TEMP="${{ runner.temp }}"
         pytest -v --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -41,7 +41,7 @@ runs:
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Test API Docstrings"
-      if: inputs.DOCTEST == true
+      if: ${{ inputs.DOCTEST }} == "true"
       shell: bash
       run: |
         echo "TMP: "$TMP
@@ -49,7 +49,7 @@ runs:
         pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
-      if: inputs.DOCTEST == true
+      if: ${{ inputs.DOCTEST }} == "true"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Separate long Core tests"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: pwsh
       run: |
         New-Item -Path ".\" -Name "local_server_test" -ItemType "directory"
-        Copy-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py", "tests\test_remote_workflow.py", "tests\test_remote_operator.py" -Destination ".\local_server_test\"
         Copy-Item -Path "tests\conftest.py" -Destination ".\local_server_test\conftest.py"
         Remove-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py"
       if: ${{inputs.MODULE}} == "core"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -40,7 +40,7 @@ runs:
         cd tests
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+        pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.${{inputs.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: "Install Test Environment"
       shell: bash
       run: |
-        pip install -r requirements_test.txt
+        pip install -r requirements/requirements_test.txt
 
     - name: "Set TMP"
       shell: bash

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -54,7 +54,7 @@ runs:
     - name: "Test API 2"
       shell: bash
       run: |
-        cd ../local_server_test
+        cd local_server_test
         pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
       if: ${{inputs.MODULE}} == "core"
 

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -1,5 +1,5 @@
-name: "Build DPF Package"
-description: "Builds the DPF package"
+name: "Test DPF Package"
+description: "Tests the DPF package"
 inputs:
   MODULE:
     description: "Module name"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -47,7 +47,7 @@ runs:
       run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
+        pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml src/ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
       if: inputs.DOCTEST == 'true'

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -32,7 +32,7 @@ runs:
         pytest --doctest-modules --durations=10 --durations-min=1.0 --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
-      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Separate long Core tests"
       shell: pwsh
@@ -59,7 +59,7 @@ runs:
       if: ${{inputs.MODULE}} == "core"
 
     - name: "Kill all servers"
-      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Upload Docstring Test Results"
       uses: actions/upload-artifact@v2

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -8,6 +8,10 @@ inputs:
   DEBUG:
     description: "Debug print mode"
     required: false
+  DOCTEST:
+    description: "Whether to test the docstrings"
+    required: true
+    default: "true"
 
 runs:
   using: "composite"
@@ -37,6 +41,7 @@ runs:
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Test API Docstrings"
+      if: inputs.DOCTEST == true
       shell: bash
       run: |
         echo "TMP: "$TMP
@@ -44,6 +49,7 @@ runs:
         pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
+      if: inputs.DOCTEST == true
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Separate long Core tests"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -17,13 +17,22 @@ runs:
       run: |
         pip install -r requirements_test.txt
 
-    - name: "Set TMP"
+    - name: "Check TMP"
       shell: bash
       run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
+
+    - name: "Set TMP"
+      shell: bash
+      run: |
         export TMP=${{ runner.temp }}
         export TEMP=${{ runner.temp }}
+      if: ${{ runner.os }} == "Linux"
+
+    - name: "Check TMP again"
+      shell: bash
+      run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
 
@@ -33,7 +42,9 @@ runs:
     - name: "Test API Docstrings"
       shell: bash
       run: |
-        pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
+        echo "TMP: "$TMP
+        echo "TEMP: "$TEMP
+        pytest --doctest-modules --durations=0 --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
@@ -42,6 +53,8 @@ runs:
       shell: bash
       run: |
         cd tests
+        echo "TMP: "$TMP
+        echo "TEMP: "$TEMP
         pytest -v --durations=0 --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -20,15 +20,16 @@ runs:
     - name: "Set TMP"
       shell: bash
       run: |
-        echo "TMP: "+$TMP
-        echo "TEMP: "+$TEMP
+        echo "TMP: "$TMP
+        echo "TEMP: "$TEMP
         echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
         echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
+        echo "TMP: "$TMP
+        echo "TEMP: "$TEMP
 
     - name: "Test API Docstrings"
       shell: bash
       run: |
-        echo $TMP
         pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: "Debug mode"
       shell: bash
-      if: inputs.DEBUG == true
+      if: inputs.DEBUG == 'true'
       run: |
         echo "DEBUG=-v --durations=10 --durations-min=1.0" >> $GITHUB_ENV
 
@@ -42,7 +42,7 @@ runs:
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Test API Docstrings"
-      if: inputs.DOCTEST == true
+      if: inputs.DOCTEST == 'true'
       shell: bash
       run: |
         echo "TMP: "$TMP
@@ -50,7 +50,7 @@ runs:
         pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
-      if: inputs.DOCTEST == true
+      if: inputs.DOCTEST == 'true'
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Separate long Core tests"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -17,10 +17,13 @@ runs:
       run: |
         pip install -r requirements_test.txt
 
+    - name: "Set TMP"
+      shell: bash
+      run: echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
+
     - name: "Test API Docstrings"
       shell: bash
       run: |
-        export TEMP=${{ runner.temp }}
         pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
@@ -37,10 +40,9 @@ runs:
 #      if: ${{ runner.os }} == "Linux"
 
     - name: "Test API"
-      shell: pwsh
+      shell: bash
       run: |
         cd tests
-        $env:TEMP="${{ runner.temp }}"
         pytest -v --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -30,11 +30,11 @@ runs:
       run: |
         echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
         echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
-      if: ${{ runner.os }} == "Linux"
+      if: runner.os == 'Linux'
 
     - name: "Debug mode"
       shell: bash
-      if: ${{ inputs.DEBUG }} == "true"
+      if: inputs.DEBUG == true
       run: |
         echo "DEBUG=-v --durations=10 --durations-min=1.0" >> $GITHUB_ENV
 
@@ -72,7 +72,7 @@ runs:
         Remove-Item -Path "tests\test_workflow.py"
         Remove-Item -Path "tests\test_remote_workflow.py"
         Remove-Item -Path "tests\test_remote_operator.py"
-      if: ${{inputs.MODULE}} == "core"
+      if: inputs.MODULE == 'core'
 
     - name: "Test API"
       shell: bash
@@ -90,7 +90,7 @@ runs:
       run: |
         cd local_server_test
         pytest $DEBUG --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
-      if: ${{inputs.MODULE}} == "core"
+      if: inputs.MODULE == 'core'
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -57,6 +57,7 @@ runs:
       run: |
         New-Item -Path ".\" -Name "local_server_test" -ItemType "directory"
         Copy-Item -Path "tests\conftest.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_launcher.py" -Destination ".\local_server_test\"
         Copy-Item -Path "tests\test_server.py" -Destination ".\local_server_test\"
         Copy-Item -Path "tests\test_local_server.py" -Destination ".\local_server_test\"
         Copy-Item -Path "tests\test_multi_server.py" -Destination ".\local_server_test\"
@@ -64,6 +65,7 @@ runs:
         Copy-Item -Path "tests\test_remote_workflow.py" -Destination ".\local_server_test\"
         Copy-Item -Path "tests\test_remote_operator.py" -Destination ".\local_server_test\"
         Remove-Item -Path "tests\test_server.py"
+        Remove-Item -Path "tests\test_launcher.py"
         Remove-Item -Path "tests\test_local_server.py"
         Remove-Item -Path "tests\test_multi_server.py"
         Remove-Item -Path "tests\test_workflow.py"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -22,10 +22,13 @@ runs:
       run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
-        echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
+        export TMP=${{ runner.temp }}
+        export TEMP=${{ runner.temp }}
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
+
+#        echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
+#        echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
 
     - name: "Test API Docstrings"
       shell: bash

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --doctest-modules --durations=0.5 --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
+        pytest --doctest-modules --durations=10 --durations-min=1.0 --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
@@ -40,7 +40,7 @@ runs:
         cd tests
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --durations=0.5 --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+        pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -56,9 +56,19 @@ runs:
       shell: pwsh
       run: |
         New-Item -Path ".\" -Name "local_server_test" -ItemType "directory"
-        Copy-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py", "tests\test_remote_workflow.py", "tests\test_remote_operator.py" -Destination ".\local_server_test\"
-        Copy-Item -Path "tests\conftest.py" -Destination ".\local_server_test\conftest.py"
-        Remove-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py", "tests\test_remote_workflow.py", "tests\test_remote_operator.py"
+        Copy-Item -Path "tests\conftest.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_server.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_local_server.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_multi_server.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_workflow.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_remote_workflow.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\test_remote_operator.py" -Destination ".\local_server_test\"
+        Remove-Item -Path "tests\test_server.py"
+        Remove-Item -Path "tests\test_local_server.py"
+        Remove-Item -Path "tests\test_multi_server.py"
+        Remove-Item -Path "tests\test_workflow.py"
+        Remove-Item -Path "tests\test_remote_workflow.py"
+        Remove-Item -Path "tests\test_remote_operator.py"
       if: ${{inputs.MODULE}} == "core"
 
     - name: "Test API"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -33,6 +33,9 @@ runs:
       run: |
         echo "DEBUG=-v --durations=10 --durations-min=1.0" >> $GITHUB_ENV
 
+    - name: "Kill all servers"
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
+
     - name: "Test API Docstrings"
       shell: bash
       run: |
@@ -59,6 +62,9 @@ runs:
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
         pytest $DEBUG --cov=ansys.dpf.${{inputs.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+
+    - name: "Kill all servers"
+      uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Test API 2"
       shell: bash

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -26,8 +26,8 @@ runs:
     - name: "Set TMP"
       shell: bash
       run: |
-        export TMP=${{ runner.temp }}
-        export TEMP=${{ runner.temp }}
+        echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
+        echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
       if: ${{ runner.os }} == "Linux"
 
     - name: "Check TMP again"
@@ -36,8 +36,6 @@ runs:
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
 
-#        echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
-#        echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
 
     - name: "Test API Docstrings"
       shell: bash

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -19,7 +19,11 @@ runs:
 
     - name: "Set TMP"
       shell: bash
-      run: echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
+      run: |
+        echo "TMP: "+$TMP
+        echo "TEMP: "+$TEMP
+        echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
+        echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
 
     - name: "Test API Docstrings"
       shell: bash

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -34,6 +34,15 @@ runs:
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
 
+    - name: "Separate long Core tests"
+      shell: pwsh
+      run: |
+        New-Item -Path ".\" -Name "local_server_test" -ItemType "directory"
+        Copy-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py" -Destination ".\local_server_test\"
+        Copy-Item -Path "tests\conftest.py" -Destination ".\local_server_test\conftest.py"
+        Remove-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py"
+      if: ${{inputs.MODULE}} == "core"
+
     - name: "Test API"
       shell: bash
       run: |
@@ -41,6 +50,13 @@ runs:
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
         pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.${{inputs.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+
+    - name: "Test API 2"
+      shell: bash
+      run: |
+        cd ../local_server_test
+        pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
+      if: ${{inputs.MODULE}} == "core"
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: "Module name"
     required: true
     default: post
+  DEBUG:
+    description: "Debug print mode"
+    required: false
 
 runs:
   using: "composite"
@@ -24,12 +27,18 @@ runs:
         echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
       if: ${{ runner.os }} == "Linux"
 
+    - name: "Debug mode"
+      shell: bash
+      if: ${{ inputs.DEBUG }} == "true"
+      run: |
+        echo "DEBUG=-v --durations=10 --durations-min=1.0" >> $GITHUB_ENV
+
     - name: "Test API Docstrings"
       shell: bash
       run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --doctest-modules --durations=10 --durations-min=1.0 --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
+        pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
@@ -49,13 +58,13 @@ runs:
         cd tests
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.${{inputs.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+        pytest $DEBUG --cov=ansys.dpf.${{inputs.MODULE}} --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Test API 2"
       shell: bash
       run: |
         cd local_server_test
-        pytest --durations=10 --durations-min=1.0 --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
+        pytest $DEBUG --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
       if: ${{inputs.MODULE}} == "core"
 
     - name: "Kill all servers"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -58,7 +58,7 @@ runs:
         New-Item -Path ".\" -Name "local_server_test" -ItemType "directory"
         Copy-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py", "tests\test_remote_workflow.py", "tests\test_remote_operator.py" -Destination ".\local_server_test\"
         Copy-Item -Path "tests\conftest.py" -Destination ".\local_server_test\conftest.py"
-        Remove-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py"
+        Remove-Item -Path "tests\test_local_server.py","tests\test_multi_server.py", "tests\test_workflow.py", "tests\test_remote_workflow.py", "tests\test_remote_operator.py"
       if: ${{inputs.MODULE}} == "core"
 
     - name: "Test API"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -24,6 +24,7 @@ runs:
     - name: "Test API Docstrings"
       shell: bash
       run: |
+        echo $TMP
         pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -7,7 +7,8 @@ inputs:
     default: post
   DEBUG:
     description: "Debug print mode"
-    required: false
+    required: true
+    default: "false"
   DOCTEST:
     description: "Whether to test the docstrings"
     required: true
@@ -29,11 +30,11 @@ runs:
       run: |
         echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
         echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
-      if: ${{ runner.os }} == "Linux"
+      if: runner.os == Linux
 
     - name: "Debug mode"
       shell: bash
-      if: ${{ inputs.DEBUG }} == "true"
+      if: inputs.DEBUG == true
       run: |
         echo "DEBUG=-v --durations=10 --durations-min=1.0" >> $GITHUB_ENV
 
@@ -41,7 +42,7 @@ runs:
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Test API Docstrings"
-      if: ${{ inputs.DOCTEST }} == "true"
+      if: inputs.DOCTEST == true
       shell: bash
       run: |
         echo "TMP: "$TMP
@@ -49,7 +50,7 @@ runs:
         pytest --doctest-modules $DEBUG --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
-      if: ${{ inputs.DOCTEST }} == "true"
+      if: inputs.DOCTEST == true
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2
 
     - name: "Separate long Core tests"
@@ -71,7 +72,7 @@ runs:
         Remove-Item -Path "tests\test_workflow.py"
         Remove-Item -Path "tests\test_remote_workflow.py"
         Remove-Item -Path "tests\test_remote_operator.py"
-      if: ${{inputs.MODULE}} == "core"
+      if: inputs.MODULE == core
 
     - name: "Test API"
       shell: bash
@@ -89,7 +90,7 @@ runs:
       run: |
         cd local_server_test
         pytest $DEBUG --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
-      if: ${{inputs.MODULE}} == "core"
+      if: inputs.MODULE == core
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -29,21 +29,11 @@ runs:
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
 
-#    - name: "Get TEMP Windows"
-#      shell: cmd
-#      run: SET TEMP=${{ runner.temp }}
-#      if: ${{ runner.os }} == "Windows"
-#
-#    - name: "Get TEMP Ubuntu"
-#      shell: bash
-#      run: export TEMP=${{ runner.temp }}
-#      if: ${{ runner.os }} == "Linux"
-
     - name: "Test API"
       shell: bash
       run: |
         cd tests
-        pytest -v --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+        pytest -v --durations=0 --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -26,10 +26,21 @@ runs:
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
 
+#    - name: "Get TEMP Windows"
+#      shell: cmd
+#      run: SET TEMP=${{ runner.temp }}
+#      if: ${{ runner.os }} == "Windows"
+#
+#    - name: "Get TEMP Ubuntu"
+#      shell: bash
+#      run: export TEMP=${{ runner.temp }}
+#      if: ${{ runner.os }} == "Linux"
+
     - name: "Test API"
       shell: bash
       run: |
         cd tests
+        echo ${{ runner.temp }} | sed -e 's/\/\\/g'
         export TEMP=${{ runner.temp }}
         pytest -v --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -16,6 +16,7 @@ runs:
       shell: bash
       run: |
         pip install -r requirements_test.txt
+        export TEMP=${{ runner.temp }}
 
     - name: "Test API Docstrings"
       shell: bash

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -30,6 +30,7 @@ runs:
       shell: bash
       run: |
         cd tests
+        export TEMP=${{ runner.temp }}
         pytest -v --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -30,11 +30,11 @@ runs:
       run: |
         echo "TMP=${{ runner.temp }}" >> $GITHUB_ENV
         echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
-      if: runner.os == Linux
+      if: ${{ runner.os }} == "Linux"
 
     - name: "Debug mode"
       shell: bash
-      if: inputs.DEBUG == true
+      if: ${{ inputs.DEBUG }} == "true"
       run: |
         echo "DEBUG=-v --durations=10 --durations-min=1.0" >> $GITHUB_ENV
 
@@ -72,7 +72,7 @@ runs:
         Remove-Item -Path "tests\test_workflow.py"
         Remove-Item -Path "tests\test_remote_workflow.py"
         Remove-Item -Path "tests\test_remote_operator.py"
-      if: inputs.MODULE == core
+      if: ${{inputs.MODULE}} == "core"
 
     - name: "Test API"
       shell: bash
@@ -90,7 +90,7 @@ runs:
       run: |
         cd local_server_test
         pytest $DEBUG --cov=ansys.dpf.core --cov-report=xml --cov-report=html --cov-append --log-level=ERROR --junitxml=../tests/junit/test-results2.xml --reruns 2 .
-      if: inputs.MODULE == core
+      if: ${{inputs.MODULE}} == "core"
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.2

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -17,12 +17,6 @@ runs:
       run: |
         pip install -r requirements_test.txt
 
-    - name: "Check TMP"
-      shell: bash
-      run: |
-        echo "TMP: "$TMP
-        echo "TEMP: "$TEMP
-
     - name: "Set TMP"
       shell: bash
       run: |
@@ -30,19 +24,12 @@ runs:
         echo "TEMP=${{ runner.temp }}" >> $GITHUB_ENV
       if: ${{ runner.os }} == "Linux"
 
-    - name: "Check TMP again"
-      shell: bash
-      run: |
-        echo "TMP: "$TMP
-        echo "TEMP: "$TEMP
-
-
     - name: "Test API Docstrings"
       shell: bash
       run: |
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest --doctest-modules --durations=0 --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
+        pytest --doctest-modules --durations=0.5 --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0
@@ -53,7 +40,7 @@ runs:
         cd tests
         echo "TMP: "$TMP
         echo "TEMP: "$TEMP
-        pytest -v --durations=0 --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
+        pytest --durations=0.5 --cov=ansys.dpf.post --cov-report=xml --cov-report=html --log-level=ERROR --junitxml=junit/test-results.xml --reruns 2 .
 
     - name: "Kill all servers"
       uses: pyansys/pydpf-actions/kill-dpf-servers@v2.0

--- a/test_package/action.yml
+++ b/test_package/action.yml
@@ -16,11 +16,11 @@ runs:
       shell: bash
       run: |
         pip install -r requirements_test.txt
-        export TEMP=${{ runner.temp }}
 
     - name: "Test API Docstrings"
       shell: bash
       run: |
+        export TEMP=${{ runner.temp }}
         pytest --doctest-modules --junitxml=junit/test-doctests-results.xml ansys/dpf/${{inputs.MODULE}}
 
     - name: "Kill all servers"


### PR DESCRIPTION
Let's use [build](https://pypi.org/project/build/) instead of `python setup.py` to build our packages. This is compatible with both the legacy `setup.py` and new `pyproject.toml` standard.