### PR TITLE
Fix/install-dpf-docker patch version detection

### DIFF
--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -31,6 +31,7 @@ runs:
        TEMP=${{inputs.ANSYS_VERSION}}
        ANSYS_VERSION_WITH_POINT=${TEMP:0:2}.${TEMP:(-1)}
        BranchName="linux_release-"${ANSYS_VERSION_WITH_POINT}"${{inputs.standalone_suffix}}"
+       echo $BranchName
        
        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone dpf-standalone
        ls dpf-standalone/
@@ -38,7 +39,7 @@ runs:
        cd dpf-standalone/ansys/dpf/
        folder_name=`echo *`
        echo "folder_name is $folder_name"
-       PATCH_VER=${folder_name:(-4)}
+       PATCH_VER=${folder_name:(14)}
        echo "patch_ver is $PATCH_VER"
        cd ../../../
 


### PR DESCRIPTION
Now works with any patch version and not just `preX`.
Explanation:
dpf-standalone server folder name is always of the form `server_20XY_Z_patch`.
It was originally made to understand a patch of form `preX`, but it does not work for any other patch form.
Splitting at character `14` instead of character `-4` enables to take into account any patch version.

![image](https://github.com/ansys/pydpf-actions/assets/100710998/d6449f8c-8f53-40f9-883b-7e2aeb5d57af)
