### PR TITLE
Fix/docker disk usage issues

### DIFF
--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -58,7 +58,9 @@ runs:
        echo "CHECK FOR SERVER ZIP"
        ls ../docker
        mv Dockerfile ../docker/Dockerfile
-       cd ../docker
+       cd ..
+       rm -rf dpf-standalone
+       cd docker
        echo "CHECKING TO BE INCLUDED IN DOCKER IMAGE"
        echo "===================================="
        ls -a .

--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -72,4 +72,5 @@ runs:
 
        echo "docker build -t dpfv20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER} --build-arg DPF_VERSION=${{inputs.ANSYS_VERSION}} --build-arg DPF_SERVER_FILE=ansys_dpf_server_${STANDALONE_PREFIX}_v20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}.zip ."
        docker build -t dpfv20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER} --build-arg DPF_VERSION=${{inputs.ANSYS_VERSION}} --build-arg DPF_SERVER_FILE=ansys_dpf_server_${STANDALONE_PREFIX}_v20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}.zip .
+       docker buildx prune --filter "until=1h"
      shell: bash

--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -59,7 +59,9 @@ runs:
        cd ..
        echo "CHECKING TO BE INCLUDED IN DOCKER IMAGE"
        echo "===================================="
-       ls .
+       ls -a .
+       echo "===================================="
+       df . -h
        echo "===================================="
        
        echo "DPF_DOCKER=dpfv20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}" >> $GITHUB_ENV

--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -72,5 +72,5 @@ runs:
 
        echo "docker build -t dpfv20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER} --build-arg DPF_VERSION=${{inputs.ANSYS_VERSION}} --build-arg DPF_SERVER_FILE=ansys_dpf_server_${STANDALONE_PREFIX}_v20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}.zip ."
        docker build -t dpfv20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER} --build-arg DPF_VERSION=${{inputs.ANSYS_VERSION}} --build-arg DPF_SERVER_FILE=ansys_dpf_server_${STANDALONE_PREFIX}_v20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}.zip .
-       docker buildx prune --filter "until=1h"
+       docker buildx prune -f --filter "until=1h"
      shell: bash

--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -57,6 +57,10 @@ runs:
         ls dist
        fi
        cd ..
+       echo "CHECKING TO BE INCLUDED IN DOCKER IMAGE"
+       echo "===================================="
+       ls .
+       echo "===================================="
        
        echo "DPF_DOCKER=dpfv20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}" >> $GITHUB_ENV
 

--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -44,19 +44,22 @@ runs:
        cd ../../../
 
        cd dpf-standalone
-       zip -qq -r ../ansys_dpf_server_${STANDALONE_PREFIX}_v20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}.zip .
-       echo "ls check standalone zip"
-       ls .. 
-       mv Dockerfile ../Dockerfile
-       #rm -r -v !("dist")
-       find . -mindepth 1 ! -regex '^./dist\(/.*\)?' -delete
-       echo "ls . : "
-       ls .
-       if [ -d "dist" ]; then
-        echo "ls dist : "
-        ls dist
-       fi
-       cd ..
+       echo "dpf-standalone repo"
+       ls -a .
+       echo "removing unused files"
+       rm -r dist
+       rm -r tests
+       rm -r .git
+       rm -r .github
+       echo "dpf-standalone repo"
+       ls -a .
+       echo "ZIP SERVER"
+       mkdir ../docker/
+       zip -qq -r ../docker/ansys_dpf_server_${STANDALONE_PREFIX}_v20${ANSYS_VERSION_WITH_POINT}.${PATCH_VER}.zip .
+       echo "CHECK FOR SERVER ZIP"
+       ls ../docker
+       mv Dockerfile ../docker/Dockerfile
+       cd ../docker
        echo "CHECKING TO BE INCLUDED IN DOCKER IMAGE"
        echo "===================================="
        ls -a .

--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -33,7 +33,7 @@ runs:
        BranchName="linux_release-"${ANSYS_VERSION_WITH_POINT}"${{inputs.standalone_suffix}}"
        echo $BranchName
        
-       git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone dpf-standalone
+       git clone --branch $BranchName --single-branch --depth=1 https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone dpf-standalone
        ls dpf-standalone/
              
        cd dpf-standalone/ansys/dpf/

--- a/install-dpf-docker/action.yml
+++ b/install-dpf-docker/action.yml
@@ -47,10 +47,9 @@ runs:
        echo "dpf-standalone repo"
        ls -a .
        echo "removing unused files"
-       rm -r dist
-       rm -r tests
-       rm -r .git
-       rm -r .github
+       rm -rf dist
+       rm -rf .git
+       rm -rf .github
        echo "dpf-standalone repo"
        ls -a .
        echo "ZIP SERVER"

--- a/install-dpf-server/action.yml
+++ b/install-dpf-server/action.yml
@@ -34,7 +34,7 @@ runs:
         }
         $BranchName = if ("${{runner.os}}" -eq "Linux") { "linux_release-$ANSYS_VERSION_WITH_POINT" } else { "win_release-$ANSYS_VERSION_WITH_POINT" }
         echo "cloning standalone branch name: " $BranchName
-        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone dpf-standalone/v${{inputs.ANSYS_VERSION}}
+        git clone --branch $BranchName --single-branch --depth=1 https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone dpf-standalone/v${{inputs.ANSYS_VERSION}}
         echo "pwd: "
         pwd
         echo "ls: "


### PR DESCRIPTION
Initially:
- `install-dpf-server` takes 3mn30s and probably 15Go
- `install-dpf-docker` takes 7mn40s and 19Go

By cloning with `--depth==1`:
- `install-dpf-server` gets down to 30s and 2Go of install ([here](https://github.com/ansys/pydpf-core/actions/runs/8926448235/job/24517596127#step:15:17))
- `install-dpf-docker` gets down to 2mn36s and 6Go of install ([here](https://github.com/ansys/pydpf-core/actions/runs/8926448235/job/24517586251#step:12:425))

By removing useless files from Docker image:
- `install-dpf-docker` gets down to 2mn19s and 5Go of install ([here](https://github.com/ansys/pydpf-core/actions/runs/8926448235/job/24522633487#step:12:420))

By removing the dpf-standalone folder entirely after Docker image build:
- `install-dpf-docker` gets down to 4Go used ([here](https://github.com/ansys/pydpf-core/actions/runs/8926448235/job/24522993727#step:13:18))

By calling `docker buildx prune`:
- `install-dpf-docker` still at 4Go used ([here](https://github.com/ansys/pydpf-core/actions/runs/8926448235/job/24523909089#step:13:18))