### PR TITLE
fix: Update org references for install-dpf-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test_windows:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     env:
       ANSYS_VERSION: 221

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
     runs-on: windows-2022
 
     env:
-      ANSYS_VERSION: 221
-
+      ANSYS_VERSION: 261
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - id: install-dpf
         uses: ./install-dpf-server
@@ -41,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      ANSYS_VERSION: 221
+      ANSYS_VERSION: 261
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - id: install-dpf
         uses: ./install-dpf-server

--- a/install-dpf-server/action.yml
+++ b/install-dpf-server/action.yml
@@ -2,12 +2,12 @@ name: "Install DPF Server"
 description: "Install and test DPF Server for different OS and versions"
 inputs:
   dpf-standalone-TOKEN:
-    description: "github secret to access https://github.com/ansys-dpf/dpf-standalone"
+    description: "github secret to access https://github.com/ansys-internal/dpf-standalone"
     required: true
   ANSYS_VERSION:
-    description: "Ansys release version number in the format 221"
+    description: "Ansys release version number in the format 261"
     required: false
-    default: "221"
+    default: "261"
 outputs:
   SERVER:
     description: "Path to the server"
@@ -21,7 +21,7 @@ runs:
         $TEMP2 = $TEMP.ToString()
         $ANSYS_VERSION_WITH_POINT=$TEMP2.Insert(2,".")
         $BranchName = if ("${{runner.os}}" -eq "Linux") { "linux_release-$ANSYS_VERSION_WITH_POINT" } else { "win_release-$ANSYS_VERSION_WITH_POINT" }
-        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-dpf/dpf-standalone
+        git clone --branch $BranchName --single-branch https://${{inputs.dpf-standalone-TOKEN}}@github.com/ansys-internal/dpf-standalone
       shell: pwsh
       
     - run: |


### PR DESCRIPTION
- Update GitHub org references for install-dpf-server action, given that the dpf-standalone repository will be transferred to the ansys-internal org.
- PR Checks will fail until the transfer has actually been completed.